### PR TITLE
Configuration tweaks

### DIFF
--- a/website/angular.json
+++ b/website/angular.json
@@ -6,6 +6,7 @@
   },
   "version": 1,
   "newProjectRoot": "projects",
+  "defaultProject": "map4sci",
   "projects": {
     "map4sci": {
       "projectType": "application",
@@ -28,7 +29,7 @@
             "index": "projects/map4sci/src/index.html",
             "main": "projects/map4sci/src/main.ts",
             "polyfills": "projects/map4sci/src/polyfills.ts",
-            "tsConfig": "projects/map4sci/tsconfig.app.json",
+            "tsConfig": "projects/map4sci/tsconfig.json",
             "assets": [
               "projects/map4sci/src/favicon.ico",
               "projects/map4sci/src/assets"
@@ -133,6 +134,5 @@
         }
       }
     }
-  },
-  "defaultProject": "map4sci"
+  }
 }

--- a/website/angular.json
+++ b/website/angular.json
@@ -101,6 +101,11 @@
             "tsConfig": "projects/map4sci/tsconfig.spec.json",
             "karmaConfig": "projects/map4sci/karma.conf.js",
             "codeCoverage": true,
+            "codeCoverageExclude": [
+              "projects/map4sci/src/main.ts",
+              "projects/map4sci/src/polyfills.ts",
+              "projects/map4sci/src/test.ts"
+            ],
             "assets": [
               "projects/map4sci/src/favicon.ico",
               "projects/map4sci/src/assets"

--- a/website/projects/map4sci/tsconfig.compodoc.json
+++ b/website/projects/map4sci/tsconfig.compodoc.json
@@ -1,4 +1,6 @@
 {
+  "extends": "./tsconfig.json",
+  "files": [],
   "include": [
     "src/app/**/*.ts"
   ],

--- a/website/projects/map4sci/tsconfig.json
+++ b/website/projects/map4sci/tsconfig.json
@@ -1,9 +1,13 @@
-/* To learn more about this file see: https://angular.io/config/tsconfig. */
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
+    "baseUrl": "./src",
     "outDir": "../../out-tsc/app",
-    "types": []
+    "types": [],
+    "paths": {
+      "@core/*": ["app/core/*"],
+      "@shared/*": ["app/shared/*"]
+    }
   },
   "files": [
     "src/main.ts",

--- a/website/projects/map4sci/tsconfig.json
+++ b/website/projects/map4sci/tsconfig.json
@@ -6,7 +6,8 @@
     "types": [],
     "paths": {
       "@core/*": ["app/core/*"],
-      "@shared/*": ["app/shared/*"]
+      "@shared/*": ["app/shared/*"],
+      "@environment": ["environments/environment.ts"]
     }
   },
   "files": [

--- a/website/projects/map4sci/tsconfig.spec.json
+++ b/website/projects/map4sci/tsconfig.spec.json
@@ -1,6 +1,5 @@
-/* To learn more about this file see: https://angular.io/config/tsconfig. */
 {
-  "extends": "../../tsconfig.json",
+  "extends": "./tsconfig.json",
   "compilerOptions": {
     "outDir": "../../out-tsc/spec",
     "types": [


### PR DESCRIPTION
- Updated tsconfig so the 'paths' property works
  - This can now be used to fix super long include paths i.e. `../../../../core/some/import` becomes `@core/some/import`
  - https://www.typescriptlang.org/tsconfig#paths
- Tweaked coverage report